### PR TITLE
Removed false tcp protocol in finding location

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func workOnJobs(jobs <-chan ScannerScaffolding.ScanJob, results chan<- ScannerSc
 						Id:          u.String(),
 						Name:        result.Name,
 						Description: fmt.Sprintf("Found subdomain %s", result.Name),
-						Location:    fmt.Sprintf("tcp://%s", result.Name),
+						Location:    result.Name,
 						Category:    "Subdomain",
 						Severity:    "INFORMATIONAL",
 						OsiLayer:    "NETWORK",


### PR DESCRIPTION
Domains are not always available via tcp.
Its more correct to keep the domain name as it is.