### PR TITLE
Feature/docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --update upgrade && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
 
-HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --update upgrade && \
 
 # healthchecks: requires curl if not present in container
 # RUN apk --update --no-cache add curl
-HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN apk --update upgrade && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
 
+# healthchecks: requires curl if not present in container
+# RUN apk --update --no-cache add curl
+HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 
 RUN chmod +x scanner-infrastructure-amass/main

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ RUN apk --update upgrade && \
     update-ca-certificates && \
     rm -rf /var/cache/apk/*
 
-# healthchecks: requires curl if not present in container
-# RUN apk --update --no-cache add curl
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+HEALTHCHECK --interval=5s --timeout=5s --start-period=30s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 

--- a/ScannerScaffolding/ScannerScaffolding.go
+++ b/ScannerScaffolding/ScannerScaffolding.go
@@ -368,7 +368,7 @@ func (scanner ScannerScaffolding) healthyStatus() string {
 }
 
 func (scanner ScannerScaffolding) isHealthy() bool {
-	return scanner.EngineStatus.HadSuccessfulEngineConnection && scanner.InitialTestRun.Successful
+	return scanner.InitialTestRun.Successful
 }
 
 func (scanner ScannerScaffolding) generateScannerStatus() ScannerStatus {


### PR DESCRIPTION
Added a health check definition to the dockerfile. This uses CURL which is already part of the container definition. The internal status definition has been refactored: If the engine is not available, the container is no longer marked as unhealthy (to prevent container restarts when the engine is unavailable). Instead, the health of the amass container is based on (1) whether the wrapper can reach amass and (2) whether the wrappers status page is up