### PR TITLE
Ensure proper goroutine termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY main.go main.go
 COPY ScannerScaffolding/ ./ScannerScaffolding/
 RUN go build main.go
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 
 # HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,21 +16,13 @@ COPY main.go main.go
 COPY ScannerScaffolding/ ./ScannerScaffolding/
 RUN go build main.go
 
-FROM alpine
+FROM gcr.io/distroless/static
 
-RUN apk --update upgrade && \
-    apk add curl ca-certificates && \
-    update-ca-certificates && \
-    rm -rf /var/cache/apk/*
-
-HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+# HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 
-RUN chmod +x scanner-infrastructure-amass/main
-RUN addgroup -S amass_group && adduser -S -g amass_group amass_user
-
-USER amass_user
+USER nonroot
 
 ARG COMMIT_ID=unkown
 ARG REPOSITORY_URL=unkown
@@ -56,4 +48,4 @@ LABEL org.opencontainers.image.title="secureCodeBox scanner-infrastructure-amass
 
 EXPOSE 8080
 
-CMD scanner-infrastructure-amass/main
+CMD ["scanner-infrastructure-amass/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang AS builder
+FROM golang:1.13 AS builder
 
 WORKDIR /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/
 
@@ -12,7 +12,7 @@ COPY main.go main.go
 COPY ScannerScaffolding/ ./ScannerScaffolding/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build main.go
 
-FROM golang AS healthCheckbuilder
+FROM golang:1.13 AS healthCheckbuilder
 COPY healthcheck.go healthcheck.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o healthcheck healthcheck.go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build main.go
 
 FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
-
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 
 USER nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build main.go
 
 FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 
-# HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 CMD curl --fail http://localhost:8080/status || exit 1
 
 COPY --from=builder /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/main /scanner-infrastructure-amass/main
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM golang AS builder
 
 WORKDIR /go/src/github.com/secureCodeBox/scanner-infrastructure-amass/
-COPY . .
+
+COPY go.mod go.sum ./
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
 
 # Otherwise binaries would link to libaries which dont exist on alpine.
 # See: https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
 ENV CGO_ENABLED 0
 
+COPY main.go main.go
+COPY ScannerScaffolding/ ./ScannerScaffolding/
 RUN go build main.go
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,9 @@ COPY go.mod go.sum ./
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Otherwise binaries would link to libaries which dont exist on alpine.
-# See: https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
-ENV CGO_ENABLED 0
-
 COPY main.go main.go
 COPY ScannerScaffolding/ ./ScannerScaffolding/
-RUN go build main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build main.go
 
 FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,8 @@ To configure this service specify the following environment variables:
 ## Local setup
 
 1. Clone the repo into your $GOPATH
-2. Install the go dependency manager "dep"
-3. Run `dep ensure` inside your repo to load the dependencies
-4. Run `go build main.go` to compile
-5. Execute the compiled `./main` file
+2. Run `go build main.go` to compile
+3. Execute the compiled `./main` file
 
 ## Build with docker
 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/OWASP/Amass/v3 v3.4.2
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cznic/mathutil v0.0.0-20170313102836-1447ad269d64/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dennwc/base v1.0.0 h1:xlBzvBNRvkQ1LFI/jom7rr0vZsvYDKtvMM6lIpjFb3M=
 github.com/dennwc/base v1.0.0/go.mod h1:zaTDIiAcg2oKW9XhjIaRc1kJVteCFXSSW6jwmCedUaI=
@@ -246,6 +247,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.4.0/go.mod h1:NWz/XGvpEW1FyYQ7fCx4dqYBLlfTcE+A9FLAkNKqjFE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -304,6 +306,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
@@ -437,6 +440,7 @@ gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+	"os"
+)
+
+func main() {
+	_, err := http.Get("http://127.0.0.1:8080/status")
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func gatherMultipleAmassResultsIntoOneScanReport(jobID string, amassResults <-ch
 		failures <- createJobFailure(jobID, "Subdomain Scan Timed out", "Subdomainscans are limited to a two hour timeframe")
 		logger.Errorf("Scan for Job '%s' timed out!", jobID)
 		// Give the Wrapper some time to submit the failure report
-		time.Sleep(5 * Time.Second)
+		time.Sleep(5 * time.Second)
 		panic("Scan Timeouts generally mean that the scanner instance is unhealthy and needs to be restarted")
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ type Address struct {
 	Description string     `json:"DESCRIPTION"`
 }
 
-func createJobFailure(jobId, message, details string) ScannerScaffolding.JobFailure {
+func createJobFailure(jobID, message, details string) ScannerScaffolding.JobFailure {
 	return ScannerScaffolding.JobFailure{
-		JobId:        jobId,
+		JobId:        jobID,
 		ErrorMessage: message,
 		ErrorDetails: details,
 	}

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func CreateFinding(amassResult *requests.Output) ScannerScaffolding.Finding {
 // ErrorNoDNSConfig NoDNS needs to be of boolean value
 var ErrorNoDNSConfig = errors.New("Scan Parameter 'NO_DNS' must be boolean")
 
-func configureAmassScan(jobID string, target ScannerScaffolding.Target, localSystem *services.LocalSystem) (*enum.Enumeration, error) {
+func configureAmassScan(target ScannerScaffolding.Target, localSystem *services.LocalSystem) (*enum.Enumeration, error) {
 	enumeration := enum.NewEnumeration(localSystem)
 	if _, isDebug := os.LookupEnv("DEBUG"); isDebug {
 		logger.Infof("Setting up high verbosity Logger for amass.")
@@ -111,7 +111,7 @@ func workOnJobs(jobs <-chan ScannerScaffolding.ScanJob, results chan<- ScannerSc
 		for _, target := range job.Targets {
 			logger.Infof("Job '%s' is scanning subdomains for '%s'", job.JobId, target.Location)
 
-			enumeration, err := configureAmassScan(job.JobId, target, localSystem)
+			enumeration, err := configureAmassScan(target, localSystem)
 			if errors.Is(err, ErrorNoDNSConfig) {
 				failures <- createJobFailure(job.JobId, "Scan Parameter 'NO_DNS' must be boolean", "")
 			} else if err != nil {

--- a/main.go
+++ b/main.go
@@ -152,8 +152,11 @@ func workOnJobs(jobs <-chan ScannerScaffolding.ScanJob, results chan<- ScannerSc
 				logger.Error(err)
 				failures <- createJobFailure(job.JobId, "Failed to start amass scan", err.Error())
 			}
+
+			// Wait for scan to complete
 			enumeration.Done()
 
+			// Copy individual amass results over to master output channel
 			for result := range enumeration.Output {
 				masterOutput <- result
 			}

--- a/main.go
+++ b/main.go
@@ -97,8 +97,11 @@ func gatherMultipleAmassResultsIntoOneScanReport(jobID string, amassResults <-ch
 	logger.Infof("Subdomainscan '%s' found %d subdomains.", jobID, len(findings))
 
 	if err != nil {
-		logger.Warningf("Scan for Job '%s' timed out!", jobID)
 		failures <- createJobFailure(jobID, "Subdomain Scan Timed out", "Subdomainscans are limited to a two hour timeframe")
+		logger.Errorf("Scan for Job '%s' timed out!", jobID)
+		// Give the Wrapper some time to submit the failure report
+		time.Sleep(5 * Time.Second)
+		panic("Scan Timeouts generally mean that the scanner instance is unhealthy and needs to be restarted")
 	}
 
 	results <- ScannerScaffolding.JobResult{

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/OWASP/Amass/v3/requests"
-	"github.com/secureCodeBox/scanner-infrastructure-amass/ScannerScaffolding"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAbs(t *testing.T) {
@@ -17,37 +17,12 @@ func TestAbs(t *testing.T) {
 		Source:    "",
 	}
 
-	expectedFinding := ScannerScaffolding.Finding{
-		Name:        "foobar.securecodebox.io",
-		Description: "Found subdomain foobar.securecodebox.io",
-		Location:    "foobar.securecodebox.io",
-		Severity:    "INFORMATIONAL",
-		Category:    "Subdomain",
-		OsiLayer:    "NETWORK",
-	}
-
 	actualFinding := CreateFinding(&res)
 
-	compareFindings(t, expectedFinding, actualFinding)
-}
-
-func compareFindings(t *testing.T, expectedFinding, actualFinding ScannerScaffolding.Finding) {
-	if expectedFinding.Name != actualFinding.Name {
-		t.Errorf("Expected Name to be '%s', was: '%s'", expectedFinding.Name, actualFinding.Name)
-	}
-	if expectedFinding.Description != actualFinding.Description {
-		t.Errorf("Expected Description to be '%s', was: '%s'", expectedFinding.Description, actualFinding.Description)
-	}
-	if expectedFinding.Location != actualFinding.Location {
-		t.Errorf("Expected Location to be '%s', was: '%s'", expectedFinding.Location, actualFinding.Location)
-	}
-	if expectedFinding.Severity != actualFinding.Severity {
-		t.Errorf("Expected Severity to be '%s', was: '%s'", expectedFinding.Severity, actualFinding.Severity)
-	}
-	if expectedFinding.Category != actualFinding.Category {
-		t.Errorf("Expected Category to be '%s', was: '%s'", expectedFinding.Category, actualFinding.Category)
-	}
-	if expectedFinding.OsiLayer != actualFinding.OsiLayer {
-		t.Errorf("Expected OsiLayer to be '%s', was: '%s'", expectedFinding.OsiLayer, actualFinding.OsiLayer)
-	}
+	assert.Equal(t, "foobar.securecodebox.io", actualFinding.Name, "they should be equal")
+	assert.Equal(t, "Found subdomain foobar.securecodebox.io", actualFinding.Description, "they should be equal")
+	assert.Equal(t, "foobar.securecodebox.io", actualFinding.Location, "they should be equal")
+	assert.Equal(t, "INFORMATIONAL", actualFinding.Severity, "they should be equal")
+	assert.Equal(t, "Subdomain", actualFinding.Category, "they should be equal")
+	assert.Equal(t, "NETWORK", actualFinding.OsiLayer, "they should be equal")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/OWASP/Amass/v3/requests"
+	"github.com/secureCodeBox/scanner-infrastructure-amass/ScannerScaffolding"
+)
+
+func TestAbs(t *testing.T) {
+
+	res := requests.Output{
+		Name:      "foobar.securecodebox.io",
+		Domain:    "securecodebox.io",
+		Addresses: nil,
+		Tag:       "",
+		Source:    "",
+	}
+
+	expectedFinding := ScannerScaffolding.Finding{
+		Name:        "foobar.securecodebox.io",
+		Description: "Found subdomain foobar.securecodebox.io",
+		Location:    "foobar.securecodebox.io",
+		Severity:    "INFORMATIONAL",
+		Category:    "Subdomain",
+		OsiLayer:    "NETWORK",
+	}
+
+	actualFinding := CreateFinding(&res)
+
+	compareFindings(t, expectedFinding, actualFinding)
+}
+
+func compareFindings(t *testing.T, expectedFinding, actualFinding ScannerScaffolding.Finding) {
+	if expectedFinding.Name != actualFinding.Name {
+		t.Errorf("Expected Name to be '%s', was: '%s'", expectedFinding.Name, actualFinding.Name)
+	}
+	if expectedFinding.Description != actualFinding.Description {
+		t.Errorf("Expected Description to be '%s', was: '%s'", expectedFinding.Description, actualFinding.Description)
+	}
+	if expectedFinding.Location != actualFinding.Location {
+		t.Errorf("Expected Location to be '%s', was: '%s'", expectedFinding.Location, actualFinding.Location)
+	}
+	if expectedFinding.Severity != actualFinding.Severity {
+		t.Errorf("Expected Severity to be '%s', was: '%s'", expectedFinding.Severity, actualFinding.Severity)
+	}
+	if expectedFinding.Category != actualFinding.Category {
+		t.Errorf("Expected Category to be '%s', was: '%s'", expectedFinding.Category, actualFinding.Category)
+	}
+	if expectedFinding.OsiLayer != actualFinding.OsiLayer {
+		t.Errorf("Expected OsiLayer to be '%s', was: '%s'", expectedFinding.OsiLayer, actualFinding.OsiLayer)
+	}
+}


### PR DESCRIPTION
I've noticed some weird log messages showing up, which indicated that the scanner wrapper was trying to submit failure reports for scan timeouts which were actually completed sucessfully hours earlier.

It seems that the go channel were the results of the amass scans are collected was never properly closed, which caused the timeout mechanism to trigger as the goroutine was still running after the scan completion.