### PR TITLE
Adding a new AMASS Attribute field "subdomain" for a better "analytical readability" later on

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func CreateFinding(amassResult *requests.Output) ScannerScaffolding.Finding {
 	attributes["NAME"] = amassResult.Name
 	attributes["SOURCE"] = amassResult.Source
 	attributes["DOMAIN"] = amassResult.Domain
+	attributes["SUBDOMAIN"] = amassResult.Name
 	attributes["ADDRESSES"] = addresses
 
 	return ScannerScaffolding.Finding{


### PR DESCRIPTION
Adding the subdomain identifier as a seperate named attribute for a better identification. This attribute "attribute.subdomain" can be selected and used for Kibana Dashboards and is more concrete than just "attribute.name". From an analytical point fo view the "attribute.subdomain" leads to a better readability.